### PR TITLE
NaN problem fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ _[Important Notes]:_
 
 2. In a similar way, the Hamming distance computation used in train.py for performance visualization is currently hard-coded for batch_sizes=1. Modifying this, however, should be much simpler...
 
-3. I experienced the typical problem of the gradients becoming _nan_ when training with a max_sequence_length of 20. I have not been able to find any robust solution to this problem, but the code seems to converge when trained with a sequence length of 10. Some have suggested to perform _curriculum learning_ to avoid this issue, but I currently have not tried this option.
-
 ## Local Environment Specifications
 
 The model was trained and tested on a machine with:

--- a/memory.py
+++ b/memory.py
@@ -152,7 +152,7 @@ class Memory:
         """
         sharp_gamma = tf.expand_dims(sharp_gamma,1)
         powed_conv_w = tf.pow(after_conv_shift, sharp_gamma)
-        return powed_conv_w / tf.expand_dims(tf.reduce_sum(powed_conv_w,1),1)
+        return powed_conv_w / ( tf.expand_dims(tf.reduce_sum(powed_conv_w,1),1) + 1e-10 )
 
     def update_memory(self, memory_matrix, write_weighting, add_vector, erase_vector):
         """


### PR DESCRIPTION
The problem was the sharpening function in memory.py which had a division with no guarantee that the denominator is not zero.

I have tested it by starting to learn from a checkpoint which was very close to outputting NaNs (it always happened in a couple of hundred iterations) and with this fix it worked fine for 300k more iterations.

Of course the result of the loss function changed a little at first, so this is not a 100% guarantee, but I'm confident this patch removes one possibility for the NaN problem.